### PR TITLE
fix: send canvas data after editor reloading

### DIFF
--- a/packages/editor/src/Editor.tsx
+++ b/packages/editor/src/Editor.tsx
@@ -1051,7 +1051,7 @@ const EditorContent = memo(
           }
 
           case "@easyblocks-editor/canvas-loaded": {
-            setCanvasLoaded(true);
+            setCanvasLoaded((loaded) => !loaded);
             break;
           }
 


### PR DESCRIPTION
Fixed a bug with reloading editor data. When the editor is loaded a second time, the canvas remains empty because no data has been passed to it. This happens because `canvasLoaded` is already set to true, we need to update it for the hook to work. _This state is not used anywhere else, so we don't care at all whether it is true or false._