### PR TITLE
fix: allow null to be the default value

### DIFF
--- a/packages/core/src/compiler/definitions.ts
+++ b/packages/core/src/compiler/definitions.ts
@@ -658,7 +658,9 @@ export const schemaPropDefinitions: SchemaPropDefinitionProviders = {
       normalize: (value) => {
         if (customTypeDefinition.type === "inline") {
           const defaultValue =
-            schemaProp.defaultValue ?? customTypeDefinition.defaultValue;
+            typeof schemaProp.defaultValue !== "undefined"
+              ? schemaProp.defaultValue
+              : customTypeDefinition.defaultValue;
 
           const normalizeScalar = (v: any) => {
             if (isLocalValue(v)) {

--- a/packages/core/src/components/ComponentBuilder/ComponentBuilder.tsx
+++ b/packages/core/src/components/ComponentBuilder/ComponentBuilder.tsx
@@ -516,6 +516,7 @@ function mapExternalProps(
         // FIXME: this is a mess
         (!isTrulyResponsiveValue(propValue) &&
           typeof propValue === "object" &&
+          propValue !== null &&
           "id" in propValue &&
           "widgetId" in propValue &&
           !("value" in propValue)) ||
@@ -523,7 +524,7 @@ function mapExternalProps(
           responsiveValueValues(propValue).every(
             (v) =>
               typeof v === "object" &&
-              v &&
+              v !== null &&
               "id" in v &&
               "widgetId" in v &&
               !("value" in v)


### PR DESCRIPTION
Fixed a bug that replaced `null` with `undefined` for the default value.

Fixed a bug that blocked the use of `null` as a valid value for a field.