### PR TITLE
add the ability to disable editor shortcuts

### DIFF
--- a/packages/core/src/compiler/types.ts
+++ b/packages/core/src/compiler/types.ts
@@ -143,4 +143,5 @@ export type EditorContextType = CompilationContextType & {
   setFocussedField: (focusedFields: string | Array<string>) => void;
   actions: EditorActions;
   templates?: Template[];
+  disableShortcuts: boolean;
 };

--- a/packages/editor/src/Editor.tsx
+++ b/packages/editor/src/Editor.tsx
@@ -932,6 +932,7 @@ const EditorContent = memo(
         compilationCache: compilationCache,
         readOnly: props.readOnly,
         disableCustomTemplates: config.disableCustomTemplates ?? false,
+        disableShortcuts: Boolean(props.disableShortcuts),
         rootComponent: findComponentDefinitionById(
           initialEntry._component,
           compilationContext
@@ -958,6 +959,7 @@ const EditorContent = memo(
       config.disableCustomTemplates,
       props.readOnly,
       props.widgets,
+      props.disableShortcuts,
       syncTemplates,
       templates,
     ]);

--- a/packages/editor/src/EditorContext.ts
+++ b/packages/editor/src/EditorContext.ts
@@ -62,6 +62,7 @@ export type EditorContextType = Omit<
   isAdminMode: boolean;
   readOnly: boolean;
   disableCustomTemplates: boolean;
+  disableShortcuts: boolean;
   types: Record<
     string,
     | EditorExternalTypeDefinition

--- a/packages/editor/src/useEditorGlobalKeyboardShortcuts.ts
+++ b/packages/editor/src/useEditorGlobalKeyboardShortcuts.ts
@@ -20,7 +20,15 @@ const DATA_TRANSFER_FORMAT = "text/x-shopstory";
 
 function useEditorGlobalKeyboardShortcuts(editorContext: EditorContextType) {
   useEffect(() => {
-    const { focussedField: focusedFields, actions } = editorContext;
+    const {
+      focussedField: focusedFields,
+      actions,
+      disableShortcuts = false,
+    } = editorContext;
+
+    if (disableShortcuts) {
+      return;
+    }
 
     function handleKeydown(event: KeyboardEvent): void {
       if (isTargetInputElement(event.target)) {


### PR DESCRIPTION
https://app.asana.com/1/1126683767705082/project/1207329739803731/task/1210136850352830?focus=true

## Description

[The previous pull request](https://github.com/swellstores/easyblocks/pull/12) added the ability to disable keyboard shortcuts for the canvas only. This pull request extends that functionality to the editor.